### PR TITLE
Make `RunContext` registers public & `Relocatable`s

### DIFF
--- a/pkg/vm/run_context.go
+++ b/pkg/vm/run_context.go
@@ -5,7 +5,7 @@ import "github.com/lambdaclass/cairo-vm.go/pkg/vm/memory"
 // RunContext containts the register states of the
 // Cairo VM.
 type RunContext struct {
-	pc memory.Relocatable
-	ap uint
-	fp uint
+	Pc memory.Relocatable
+	Ap memory.Relocatable
+	Fp memory.Relocatable
 }


### PR DESCRIPTION
Keeping only the offsets for ap 7 fp is an optimization, and can be avoided if the purpose of this project is to teach how to build a VM.
Also register values should be public