### PR TITLE
Makefile: Clean lambdaworks lib in `clean` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,8 @@ clean:
 	rm -f $(TEST_DIR)/*.json
 	rm -f $(TEST_DIR)/*.memory
 	rm -f $(TEST_DIR)/*.trace
+	cd pkg/lambdaworks/lib/lambdaworks && cargo clean
+	rm pkg/lambdaworks/lib/liblambdaworks.a
 	rm -rf cairo-vm
 	rm -r cairo-vm-env
 


### PR DESCRIPTION
Sometimes the lib breaks and causes linker errors when running tests, running make clean and make build again should fix the problem