### PR TITLE
Use `uint64` to represent `Felt` limbs instead of C type

### DIFF
--- a/pkg/lambdaworks/lambdaworks.go
+++ b/pkg/lambdaworks/lambdaworks.go
@@ -12,12 +12,9 @@ import (
 	"unsafe"
 )
 
-// Go representation of a single limb (unsigned integer with 64 bits).
-type Limb C.limb_t
-
 // Go representation of a 256 bit prime field element (felt).
 type Felt struct {
-	limbs [4]Limb
+	limbs [4]uint64
 }
 
 // Converts a Go Felt to a C felt_t.
@@ -31,9 +28,9 @@ func (f Felt) toC() C.felt_t {
 
 // Converts a C felt_t to a Go Felt.
 func fromC(result C.felt_t) Felt {
-	var limbs [4]Limb
+	var limbs [4]uint64
 	for i, limb := range result {
-		limbs[i] = Limb(limb)
+		limbs[i] = uint64(limb)
 	}
 	return Felt{limbs: limbs}
 }


### PR DESCRIPTION
When integrating other dynamic libs, it was imposible to convert values back to `Felt` without importing the `Limb` type in the dynamic libs (which is not that simple given C's lack of package management). This PR aims to make that conversion easier and also lessen the dependency on C types for the Felt struct