### PR TITLE
Test RelocateSegment used before computing used

### DIFF
--- a/pkg/vm/memory/segments_test.go
+++ b/pkg/vm/memory/segments_test.go
@@ -128,6 +128,14 @@ func TestGetSegmentUsedSizeBeforeComputingUsed(t *testing.T) {
 	}
 }
 
+func TestRelocateSegmentUsedSizeBeforeComputingSegment(t *testing.T) {
+	segments := memory.NewMemorySegmentManager()
+	_, ok := segments.RelocateSegments()
+	if !ok {
+		t.Errorf("Expected no segment sizes loaded")
+	}
+}
+
 func TestRelocateOneSegment(t *testing.T) {
 	segments := memory.NewMemorySegmentManager()
 	segments.AddSegment()


### PR DESCRIPTION
closes #121 
added TestRelocateSegmentUsedSizeBeforeComputingSegment