### PR TITLE
Test GetRelocateTrace without relocating trace

### DIFF
--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -519,6 +519,14 @@ func TestDeduceMemoryCellNoBuiltins(t *testing.T) {
 	}
 }
 
+func TestRelocateTraceWithoutRelocatingTrace(t *testing.T) {
+	virtualMachine := vm.NewVirtualMachine()
+	_, err := virtualMachine.GetRelocatedTrace()
+	if err == nil {
+		t.Fatalf("GetRelocatedTrace should have failed")
+	}
+}
+
 func TestRelocateTraceOneEntry(t *testing.T) {
 	virtualMachine := vm.NewVirtualMachine()
 	buildTestProgramMemory(virtualMachine)


### PR DESCRIPTION
closes #122 
added TestGetRelocateTraceWithoutRelocatingTrace