### PR TITLE
Make test target depend on `build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ deps-macos:
 run:
 	@go run cmd/cli/main.go
 
-test: $(COMPILED_TESTS)
+test: build $(COMPILED_TESTS)
 	@go test -v ./...
 
 coverage: $(COMPILED_TESTS)


### PR DESCRIPTION
Currently the `test` target does not depend on `build`, so if you haven't built the lamdaworks library tests just fail with a linker error message