### PR TITLE
Proof mode make targets (re-upload)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
     - name: Compare trace & memory with cairo-vm
       run: make compare_trace_memory
 
+    - name: Compare trace & memory with cairo-vm in proof mode
+      run: make compare_proof_trace_memory
+
   demos:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,27 @@ $(TEST_DIR)/%.go.trace $(TEST_DIR)/%.go.memory: $(TEST_DIR)/%.json
 $(TEST_DIR)/%.json: $(TEST_DIR)/%.cairo
 	cairo-compile --cairo_path="$(TEST_DIR)" $< --output $@
 
+# Create proof mode programs
+
+TEST_PROOF_DIR=cairo_programs/proof_programs
+TEST_PROOF_FILES:=$(wildcard $(TEST_PROOF_DIR)/*.cairo)
+COMPILED_PROOF_TESTS:=$(patsubst $(TEST_PROOF_DIR)/%.cairo, $(TEST_PROOF_DIR)/%.json, $(TEST_PROOF_FILES))
+
+CAIRO_RS_PROOF_MEM:=$(patsubst $(TEST_PROOF_DIR)/%.json, $(TEST_PROOF_DIR)/%.rs.memory, $(COMPILED_PROOF_TESTS))
+CAIRO_RS_PROOF_TRACE:=$(patsubst $(TEST_PROOF_DIR)/%.json, $(TEST_PROOF_DIR)/%.rs.trace, $(COMPILED_PROOF_TESTS))
+
+CAIRO_GO_PROOF_MEM:=$(patsubst $(TEST_PROOF_DIR)/%.json, $(TEST_PROOF_DIR)/%.go.memory, $(COMPILED_PROOF_TESTS))
+CAIRO_GO_PROOF_TRACE:=$(patsubst $(TEST_PROOF_DIR)/%.json, $(TEST_PROOF_DIR)/%.go.trace, $(COMPILED_PROOF_TESTS))
+
+$(TEST_PROOF_DIR)/%.json: $(TEST_PROOF_DIR)/%.cairo
+	cairo-compile --cairo_path="$(TEST_PROOF_DIR)" $< --output $@ --proof_mode
+
+$(TEST_PROOF_DIR)/%.rs.trace $(TEST_PROOF_DIR)/%.rs.memory: $(TEST_PROOF_DIR)/%.json $(CAIRO_VM_CLI)
+	$(CAIRO_VM_CLI) --layout all_cairo $< --trace_file $(@D)/$(*F).rs.trace --memory_file $(@D)/$(*F).rs.memory --proof_mode
+
+$(TEST_PROOF_DIR)/%.go.trace $(TEST_PROOF_DIR)/%.go.memory: $(TEST_PROOF_DIR)/%.json
+	go run cmd/cli/main.go $(@D)/$(*F).json --trace_file $(@D)/$(*F).go.trace --memory_file $(@D)/$($*F).go.memory --proof_mode
+
 # Creates a pyenv and installs cairo-lang
 deps:
 	pyenv install  -s 3.9.15
@@ -134,4 +155,13 @@ compare_trace: build_cairo_vm_cli $(CAIRO_RS_TRACE) $(CAIRO_GO_TRACE)
 
 compare_memory: build_cairo_vm_cli $(CAIRO_RS_MEM) $(CAIRO_GO_MEM)
 	cd scripts; sh compare_vm_state.sh memory
+
+compare_proof_trace_memory: build_cairo_vm_cli $(CAIRO_RS_PROOF_MEM) $(CAIRO_RS_PROOF_TRACE) $(CAIRO_GO_PROOF_MEM) $(CAIRO_GO_PROOF_TRACE)
+	cd scripts; sh compare_vm_state.sh trace memory proof_mode
+
+compare_proof_trace: build_cairo_vm_cli $(CAIRO_RS_PROOF_TRACE) $(CAIRO_GO_PROOF_TRACE)
+	cd scripts; sh compare_vm_state.sh trace proof_mode
+
+compare_proof_memory: build_cairo_vm_cli $(CAIRO_RS_PROOF_MEM) $(CAIRO_GO_PROOF_MEM)
+	cd scripts; sh compare_vm_state.sh memory proof_mode
 

--- a/cairo_programs/proof_programs/bitwise_builtin_test.cairo
+++ b/cairo_programs/proof_programs/bitwise_builtin_test.cairo
@@ -1,0 +1,18 @@
+%builtins bitwise
+from starkware.cairo.common.bitwise import bitwise_and, bitwise_xor, bitwise_or, bitwise_operations
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+
+func main{bitwise_ptr: BitwiseBuiltin*}() {
+    let (and_a) = bitwise_and(12, 10);  // Binary (1100, 1010).
+    assert and_a = 8;  // Binary 1000.
+    let (xor_a) = bitwise_xor(12, 10);
+    assert xor_a = 6;
+    let (or_a) = bitwise_or(12, 10);
+    assert or_a = 14;
+
+    let (and_b, xor_b, or_b) = bitwise_operations(9, 3);
+    assert and_b = 1;
+    assert xor_b = 10;
+    assert or_b = 11;
+    return ();
+}

--- a/cairo_programs/proof_programs/bitwise_builtin_test.cairo
+++ b/cairo_programs/proof_programs/bitwise_builtin_test.cairo
@@ -1,18 +1,1 @@
-%builtins bitwise
-from starkware.cairo.common.bitwise import bitwise_and, bitwise_xor, bitwise_or, bitwise_operations
-from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
-
-func main{bitwise_ptr: BitwiseBuiltin*}() {
-    let (and_a) = bitwise_and(12, 10);  // Binary (1100, 1010).
-    assert and_a = 8;  // Binary 1000.
-    let (xor_a) = bitwise_xor(12, 10);
-    assert xor_a = 6;
-    let (or_a) = bitwise_or(12, 10);
-    assert or_a = 14;
-
-    let (and_b, xor_b, or_b) = bitwise_operations(9, 3);
-    assert and_b = 1;
-    assert xor_b = 10;
-    assert or_b = 11;
-    return ();
-}
+cairo_programs/bitwise_builtin_test.cairo

--- a/cairo_programs/proof_programs/factorial.cairo
+++ b/cairo_programs/proof_programs/factorial.cairo
@@ -1,0 +1,15 @@
+// factorial(n) =  n!
+func factorial(n) -> (result: felt) {
+    if (n == 1) {
+        return (n,);
+    }
+    let (a) = factorial(n - 1);
+    return (n * a,);
+}
+
+func main() {
+    // Make sure the factorial(10) == 3628800
+    let (y) = factorial(10);
+    y = 3628800;
+    return ();
+}

--- a/cairo_programs/proof_programs/factorial.cairo
+++ b/cairo_programs/proof_programs/factorial.cairo
@@ -1,15 +1,1 @@
-// factorial(n) =  n!
-func factorial(n) -> (result: felt) {
-    if (n == 1) {
-        return (n,);
-    }
-    let (a) = factorial(n - 1);
-    return (n * a,);
-}
-
-func main() {
-    // Make sure the factorial(10) == 3628800
-    let (y) = factorial(10);
-    y = 3628800;
-    return ();
-}
+cairo_programs/factorial.cairo

--- a/cairo_programs/proof_programs/fibonacci.cairo
+++ b/cairo_programs/proof_programs/fibonacci.cairo
@@ -1,0 +1,18 @@
+func main() {
+    // Call fib(1, 1, 10).
+    let result: felt = fib(1, 1, 10);
+
+    // Make sure the 10th Fibonacci number is 144.
+    assert result = 144;
+    ret;
+}
+
+func fib(first_element, second_element, n) -> (res: felt) {
+    jmp fib_body if n != 0;
+    tempvar result = second_element;
+    return (second_element,);
+
+    fib_body:
+    tempvar y = first_element + second_element;
+    return fib(second_element, y, n - 1);
+}

--- a/cairo_programs/proof_programs/fibonacci.cairo
+++ b/cairo_programs/proof_programs/fibonacci.cairo
@@ -1,18 +1,1 @@
-func main() {
-    // Call fib(1, 1, 10).
-    let result: felt = fib(1, 1, 10);
-
-    // Make sure the 10th Fibonacci number is 144.
-    assert result = 144;
-    ret;
-}
-
-func fib(first_element, second_element, n) -> (res: felt) {
-    jmp fib_body if n != 0;
-    tempvar result = second_element;
-    return (second_element,);
-
-    fib_body:
-    tempvar y = first_element + second_element;
-    return fib(second_element, y, n - 1);
-}
+cairo_programs/fibonacci.cairo

--- a/cairo_programs/proof_programs/simple_print.cairo
+++ b/cairo_programs/proof_programs/simple_print.cairo
@@ -1,0 +1,13 @@
+%builtins output
+
+from starkware.cairo.common.serialize import serialize_word
+
+func main{output_ptr: felt*}() {
+    let x = 100;
+
+    let y = x / 2;
+
+    serialize_word(y);
+
+    ret;
+}

--- a/cairo_programs/proof_programs/simple_print.cairo
+++ b/cairo_programs/proof_programs/simple_print.cairo
@@ -1,13 +1,1 @@
-%builtins output
-
-from starkware.cairo.common.serialize import serialize_word
-
-func main{output_ptr: felt*}() {
-    let x = 100;
-
-    let y = x / 2;
-
-    serialize_word(y);
-
-    ret;
-}
+cairo_programs/simple_print.cairo

--- a/cairo_programs/proof_programs/struct.cairo
+++ b/cairo_programs/proof_programs/struct.cairo
@@ -1,0 +1,10 @@
+struct MyStruct {
+    first_member: felt,
+    second_member: felt,
+}
+
+func main() {
+    let struct_instance = MyStruct(first_member=1, second_member=2);
+    let struct_instance_2 = MyStruct(3, 4);
+    return ();
+}

--- a/cairo_programs/proof_programs/struct.cairo
+++ b/cairo_programs/proof_programs/struct.cairo
@@ -1,10 +1,1 @@
-struct MyStruct {
-    first_member: felt,
-    second_member: felt,
-}
-
-func main() {
-    let struct_instance = MyStruct(first_member=1, second_member=2);
-    let struct_instance_2 = MyStruct(3, 4);
-    return ();
-}
+cairo_programs/struct.cairo


### PR DESCRIPTION
This PR adds make targets to run trace and memory comparisons in proof mode between the rust VM and the go VM.

Re-uploaded because of issues with the CI