### PR TITLE
Add util `SetupIdsForTest` + Add methods to obtain struct field to `IdsManager`

### DIFF
--- a/pkg/hints/hint_utils/ids_manager.go
+++ b/pkg/hints/hint_utils/ids_manager.go
@@ -93,7 +93,7 @@ func (ids *IdsManager) GetAddr(name string, vm *VirtualMachine) (Relocatable, er
 		}
 
 		to access each struct field, lives will be field 0 and paws will be field 1, so to access them we can use:
-		ids_lives := ids.GetStructField("cat", 0, vm) or ids_lives := ids.Get("cat", 0, vm)
+		ids_lives := ids.GetStructField("cat", 0, vm) or ids_lives := ids.Get("cat", vm)
 		ids_paws := ids.GetStructField("cat", 1, vm)
 */
 func (ids *IdsManager) GetStructField(name string, field_off uint, vm *VirtualMachine) (*MaybeRelocatable, error) {
@@ -117,8 +117,8 @@ func (ids *IdsManager) GetStructField(name string, field_off uint, vm *VirtualMa
 		}
 
 		to access each struct field, lives will be field 0 and paws will be field 1, so to access them we can use:
-		ids_lives := ids.GetStructField("cat", 0, vm) or ids_lives := ids.Get("cat", 0, vm)
-		ids_paws := ids.GetStructField("cat", 1, vm)
+		ids_lives := ids.GetStructFieldFelt("cat", 0, vm) or ids_lives := ids.Get("cat", vm)
+		ids_paws := ids.GetStructFieldFelt("cat", 1, vm)
 */
 func (ids *IdsManager) GetStructFieldFelt(name string, field_off uint, vm *VirtualMachine) (lambdaworks.Felt, error) {
 	reference, ok := ids.References[name]

--- a/pkg/hints/hint_utils/ids_manager.go
+++ b/pkg/hints/hint_utils/ids_manager.go
@@ -136,6 +136,28 @@ func (ids *IdsManager) GetStructFieldFelt(name string, field_off uint, vm *Virtu
 	return lambdaworks.Felt{}, errors.Errorf("Unknow identifier %s", name)
 }
 
+/*
+	 Inserts value into an ids' field (given that the identifier is a sruct)
+		For example:
+
+		struct cat {
+			lives felt
+			paws felt
+		}
+
+		to access each struct field, lives will be field 0 and paws will be field 1
+		, so to set the value of cat.paws we can use:
+		ids.InsertStructField("cat", 1, vm)
+*/
+func (ids *IdsManager) InsertStructField(name string, field_off uint, value *MaybeRelocatable, vm *VirtualMachine) error {
+
+	addr, err := ids.GetAddr(name, vm)
+	if err != nil {
+		return err
+	}
+	return vm.Segments.Memory.Insert(addr.AddUint(field_off), value)
+}
+
 // Inserts value into the address of the given identifier
 func insertIdsFromReference(value *MaybeRelocatable, reference *HintReference, apTracking parser.ApTrackingData, vm *VirtualMachine) error {
 	addr, ok := getAddressFromReference(reference, apTracking, vm)

--- a/pkg/hints/hint_utils/ids_manager_test.go
+++ b/pkg/hints/hint_utils/ids_manager_test.go
@@ -257,3 +257,31 @@ func TestIdsManagerGetFeltDeref(t *testing.T) {
 		t.Errorf("IdsManager.GetFelt returned wrong value")
 	}
 }
+
+func TestIdsManagerGetStructFieldTest(t *testing.T) {
+	ids := IdsManager{
+		References: map[string]HintReference{
+			"cat": {
+				Offset1: OffsetValue{
+					Register:  vm.FP,
+					ValueType: Reference,
+				},
+				Dereference: true,
+			},
+		},
+	}
+	vm := vm.NewVirtualMachine()
+	vm.Segments.AddSegment()
+	vm.Segments.Memory.Insert(vm.RunContext.Fp, memory.NewMaybeRelocatableFelt(lambdaworks.FeltFromUint64(7)))
+	vm.Segments.Memory.Insert(vm.RunContext.Fp.AddUint(1), memory.NewMaybeRelocatableFelt(lambdaworks.FeltFromUint64(4)))
+	lives, err_lives := ids.GetStructFieldFelt("cat", 0, vm)
+	paws, err_paws := ids.GetStructFieldFelt("cat", 1, vm)
+	if err_lives != nil || err_paws != nil {
+		t.Errorf("Error(s) in test: %s, %s", err_lives, err_paws)
+	}
+	expected_lives := lambdaworks.FeltFromUint64(7)
+	expected_paws := lambdaworks.FeltFromUint64(4)
+	if lives != expected_lives || paws != expected_paws {
+		t.Errorf("IdsManager.GetStructFieldFelt returned wrong values")
+	}
+}

--- a/pkg/hints/hint_utils/testing_utils.go
+++ b/pkg/hints/hint_utils/testing_utils.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Receives a map and builds a setup for hints tests containing ids
+// For usage examples refer to testing_utils_test.go
 // Builds the IdsManager & Inserts ids into memory
 // Works as follows:
 // Each map entry represents an ids variable

--- a/pkg/hints/hint_utils/testing_utils.go
+++ b/pkg/hints/hint_utils/testing_utils.go
@@ -1,0 +1,42 @@
+package hint_utils
+
+import (
+	"github.com/lambdaclass/cairo-vm.go/pkg/vm"
+	"github.com/lambdaclass/cairo-vm.go/pkg/vm/memory"
+)
+
+// Receives a map and builds a setup for hints tests containing ids
+// Builds the IdsManager & Inserts ids into memory
+// Works as follows:
+// Each map entry represents an ids variable
+// That identifier can represent one or more elements (aka be an elment or struct)
+// Some of these elements may also be missing (inserted during the hint), and are represented as a nil pointer
+// Considerations:
+// All references will be FP-based, so please don't update the value of FP after calling this function,
+// and make sure that the memory at fp's segment is clear from its current offset onwards
+func SetupIdsForTest(ids map[string][]*memory.MaybeRelocatable, vm *vm.VirtualMachine) IdsManager {
+	manager := IdsManager{}
+	base_addr := vm.RunContext.Fp
+	current_offset := 0
+	for name, elems := range ids {
+		// Create reference
+		manager.References[name] = HintReference{
+			Dereference: true,
+			Offset1: OffsetValue{
+				ValueType: Reference,
+				Value:     current_offset,
+			},
+		}
+		// Update current_offset
+		current_offset += len(elems)
+		// Insert ids variables (if present)
+		for n, elem := range elems {
+			if elem != nil {
+				vm.Segments.Memory.Insert(base_addr.AddUint(uint(n)), elem)
+			}
+		}
+		// Update base_addr
+		base_addr.Offset += uint(len(elems))
+	}
+	return manager
+}

--- a/pkg/hints/hint_utils/testing_utils.go
+++ b/pkg/hints/hint_utils/testing_utils.go
@@ -1,7 +1,6 @@
-package hint_utils_test
+package hint_utils
 
 import (
-	. "github.com/lambdaclass/cairo-vm.go/pkg/hints/hint_utils"
 	"github.com/lambdaclass/cairo-vm.go/pkg/vm"
 	"github.com/lambdaclass/cairo-vm.go/pkg/vm/memory"
 )

--- a/pkg/hints/hint_utils/testing_utils.go
+++ b/pkg/hints/hint_utils/testing_utils.go
@@ -1,6 +1,7 @@
 package hint_utils
 
 import (
+	"github.com/lambdaclass/cairo-vm.go/pkg/parser"
 	"github.com/lambdaclass/cairo-vm.go/pkg/vm"
 	"github.com/lambdaclass/cairo-vm.go/pkg/vm/memory"
 )
@@ -15,7 +16,7 @@ import (
 // All references will be FP-based, so please don't update the value of FP after calling this function,
 // and make sure that the memory at fp's segment is clear from its current offset onwards
 func SetupIdsForTest(ids map[string][]*memory.MaybeRelocatable, vm *vm.VirtualMachine) IdsManager {
-	manager := IdsManager{}
+	manager := NewIdsManager(make(map[string]HintReference), parser.ApTrackingData{})
 	base_addr := vm.RunContext.Fp
 	current_offset := 0
 	for name, elems := range ids {

--- a/pkg/hints/hint_utils/testing_utils_test.go
+++ b/pkg/hints/hint_utils/testing_utils_test.go
@@ -1,6 +1,7 @@
-package hint_utils
+package hint_utils_test
 
 import (
+	. "github.com/lambdaclass/cairo-vm.go/pkg/hints/hint_utils"
 	"github.com/lambdaclass/cairo-vm.go/pkg/vm"
 	"github.com/lambdaclass/cairo-vm.go/pkg/vm/memory"
 )

--- a/pkg/hints/hint_utils/testing_utils_test.go
+++ b/pkg/hints/hint_utils/testing_utils_test.go
@@ -28,7 +28,35 @@ func TestSetupIdsForTestSimpleValues(t *testing.T) {
 		t.Error("Fetching ids failed")
 	}
 	if a != FeltFromUint64(17) || b != FeltFromUint64(7) {
-		t.Error("Wromg ids values")
+		t.Error("Wrong ids values")
 	}
+}
 
+func TestSetupIdsForTestSimpleValuesLeaveGap(t *testing.T) {
+	// ids.a = 17
+	// ids.b = 7
+	vm := vm.NewVirtualMachine()
+	vm.Segments.AddSegment()
+	ids := SetupIdsForTest(
+		map[string][]*MaybeRelocatable{
+			"a": []*MaybeRelocatable{NewMaybeRelocatableFelt(FeltFromUint64(17))},
+			"b": []*MaybeRelocatable{nil},
+			"c": []*MaybeRelocatable{NewMaybeRelocatableFelt(FeltFromUint64(7))},
+		},
+		vm,
+	)
+	// Check that we can fetch the values from ids
+	a, err_a := ids.GetFelt("a", vm)
+	c, err_c := ids.GetFelt("c", vm)
+	if err_a != nil || err_c != nil {
+		t.Error("Fetching ids failed")
+	}
+	if a != FeltFromUint64(17) || c != FeltFromUint64(7) {
+		t.Error("Wrong ids values")
+	}
+	// Check that we have a gap at b (we should be able to insert into it)
+	err_b := ids.Insert("b", NewMaybeRelocatableFelt(FeltFromUint64(15)), vm)
+	if err_b != nil {
+		t.Error("Failed to insert ids")
+	}
 }

--- a/pkg/hints/hint_utils/testing_utils_test.go
+++ b/pkg/hints/hint_utils/testing_utils_test.go
@@ -85,3 +85,26 @@ func TestSetupIdsForTestStruct(t *testing.T) {
 		t.Error("Wrong ids values")
 	}
 }
+
+func TestSetupIdsForTestStructWithGap(t *testing.T) {
+	/* struct Cat {
+		lives : 7 // off 0
+		paws: 4 // off 1
+
+	}*/
+	vm := vm.NewVirtualMachine()
+	vm.Segments.AddSegment()
+	ids := SetupIdsForTest(
+		map[string][]*MaybeRelocatable{
+			"cat":    {nil, nil},
+			"n_cats": {NewMaybeRelocatableFelt(FeltFromUint64(1))},
+		},
+		vm,
+	)
+	// Check that we have the appropiate gap at cat (we should be able to insert into it)
+	err_lives := ids.InsertStructField("cat", 0, NewMaybeRelocatableFelt(FeltFromUint64(7)), vm)
+	err_paws := ids.InsertStructField("cat", 1, NewMaybeRelocatableFelt(FeltFromUint64(7)), vm)
+	if err_lives != nil || err_paws != nil {
+		t.Error("Failed to insert ids")
+	}
+}

--- a/pkg/hints/hint_utils/testing_utils_test.go
+++ b/pkg/hints/hint_utils/testing_utils_test.go
@@ -1,0 +1,34 @@
+package hint_utils_test
+
+import (
+	"testing"
+
+	. "github.com/lambdaclass/cairo-vm.go/pkg/hints/hint_utils"
+	. "github.com/lambdaclass/cairo-vm.go/pkg/lambdaworks"
+	"github.com/lambdaclass/cairo-vm.go/pkg/vm"
+	. "github.com/lambdaclass/cairo-vm.go/pkg/vm/memory"
+)
+
+func TestSetupIdsForTestSimpleValues(t *testing.T) {
+	// ids.a = 17
+	// ids.b = 7
+	vm := vm.NewVirtualMachine()
+	vm.Segments.AddSegment()
+	ids := SetupIdsForTest(
+		map[string][]*MaybeRelocatable{
+			"a": []*MaybeRelocatable{NewMaybeRelocatableFelt(FeltFromUint64(17))},
+			"b": []*MaybeRelocatable{NewMaybeRelocatableFelt(FeltFromUint64(7))},
+		},
+		vm,
+	)
+	// Check that we can fetch the values from ids
+	a, err_a := ids.GetFelt("a", vm)
+	b, err_b := ids.GetFelt("b", vm)
+	if err_a != nil || err_b != nil {
+		t.Error("Fetching ids failed")
+	}
+	if a != FeltFromUint64(17) || b != FeltFromUint64(7) {
+		t.Error("Wromg ids values")
+	}
+
+}

--- a/pkg/hints/hint_utils/testing_utils_test.go
+++ b/pkg/hints/hint_utils/testing_utils_test.go
@@ -60,3 +60,28 @@ func TestSetupIdsForTestSimpleValuesLeaveGap(t *testing.T) {
 		t.Error("Failed to insert ids")
 	}
 }
+
+func TestSetupIdsForTestStruct(t *testing.T) {
+	/* struct Cat {
+		lives : 7 // off 0
+		paws: 4 // off 1
+
+	}*/
+	vm := vm.NewVirtualMachine()
+	vm.Segments.AddSegment()
+	ids := SetupIdsForTest(
+		map[string][]*MaybeRelocatable{
+			"cat": {NewMaybeRelocatableFelt(FeltFromUint64(7)), NewMaybeRelocatableFelt(FeltFromUint64(4))},
+		},
+		vm,
+	)
+	// Check that we can fetch the values from ids
+	lives, err_lives := ids.GetStructFieldFelt("cat", 0, vm)
+	paws, err_paws := ids.GetStructFieldFelt("cat", 1, vm)
+	if err_lives != nil || err_paws != nil {
+		t.Error("Fetching ids failed")
+	}
+	if lives != FeltFromUint64(7) || paws != FeltFromUint64(4) {
+		t.Error("Wrong ids values")
+	}
+}

--- a/pkg/hints/hint_utils/testing_utils_test.go
+++ b/pkg/hints/hint_utils/testing_utils_test.go
@@ -16,8 +16,8 @@ func TestSetupIdsForTestSimpleValues(t *testing.T) {
 	vm.Segments.AddSegment()
 	ids := SetupIdsForTest(
 		map[string][]*MaybeRelocatable{
-			"a": []*MaybeRelocatable{NewMaybeRelocatableFelt(FeltFromUint64(17))},
-			"b": []*MaybeRelocatable{NewMaybeRelocatableFelt(FeltFromUint64(7))},
+			"a": {NewMaybeRelocatableFelt(FeltFromUint64(17))},
+			"b": {NewMaybeRelocatableFelt(FeltFromUint64(7))},
 		},
 		vm,
 	)
@@ -39,9 +39,9 @@ func TestSetupIdsForTestSimpleValuesLeaveGap(t *testing.T) {
 	vm.Segments.AddSegment()
 	ids := SetupIdsForTest(
 		map[string][]*MaybeRelocatable{
-			"a": []*MaybeRelocatable{NewMaybeRelocatableFelt(FeltFromUint64(17))},
-			"b": []*MaybeRelocatable{nil},
-			"c": []*MaybeRelocatable{NewMaybeRelocatableFelt(FeltFromUint64(7))},
+			"a": {NewMaybeRelocatableFelt(FeltFromUint64(17))},
+			"b": {nil},
+			"c": {NewMaybeRelocatableFelt(FeltFromUint64(7))},
 		},
 		vm,
 	)


### PR DESCRIPTION
Adds function `SetupIdsForTesting` to abstract hint tests from the inner workings of ids management
Adds methods `GetStructField`, `GetStructFieldFelt` & `InsertStructField` to handle ids struct fields given their offset within the struct.
This same structure could be later on expanded to use struct data in the compiled json to obtain the struct fields from their name instead