### PR TITLE
Strip path from ids names in `CairoVmHintProcessor::CompileHint`

### DIFF
--- a/pkg/hints/hint_processor.go
+++ b/pkg/hints/hint_processor.go
@@ -2,6 +2,7 @@ package hints
 
 import (
 	"errors"
+	"strings"
 
 	. "github.com/lambdaclass/cairo-vm.go/pkg/hints/hint_utils"
 	. "github.com/lambdaclass/cairo-vm.go/pkg/lambdaworks"
@@ -24,6 +25,8 @@ func (p *CairoVmHintProcessor) CompileHint(hintParams *parser.HintParams, refere
 		if int(n) >= len(referenceManager.References) {
 			return nil, errors.New("Reference not found in ReferenceManager")
 		}
+		split := strings.Split(name, ".")
+		name = split[len(split)-1]
 		ids[name] = ParseHintReference(referenceManager.References[n])
 	}
 	return HintData{Ids: ids, Code: hintParams.Code, ApTracking: hintParams.FlowTrackingData.APTracking}, nil

--- a/pkg/hints/hint_processor_test.go
+++ b/pkg/hints/hint_processor_test.go
@@ -31,7 +31,7 @@ func TestCompileHintHappyPath(t *testing.T) {
 		FlowTrackingData: parser.FlowTrackingData{
 			APTracking: parser.ApTrackingData{Group: 1, Offset: 2},
 		},
-		ReferenceIds: map[string]uint{"__main.__a": 0, "__main__.b": 1},
+		ReferenceIds: map[string]uint{"__main.__.a": 0, "__main__.b": 1},
 	}
 	referenceManager := &parser.ReferenceManager{
 		References: []parser.Reference{

--- a/pkg/hints/hint_processor_test.go
+++ b/pkg/hints/hint_processor_test.go
@@ -31,7 +31,7 @@ func TestCompileHintHappyPath(t *testing.T) {
 		FlowTrackingData: parser.FlowTrackingData{
 			APTracking: parser.ApTrackingData{Group: 1, Offset: 2},
 		},
-		ReferenceIds: map[string]uint{"a": 0, "b": 1},
+		ReferenceIds: map[string]uint{"__main.__a": 0, "__main__.b": 1},
 	}
 	referenceManager := &parser.ReferenceManager{
 		References: []parser.Reference{


### PR DESCRIPTION
Without this, hints will need to use the full path to interact with ids variables, this path can't be determined, as a hint can be ran anywhere in a cairo program