### PR TITLE
Use gcd for divmod

### DIFF
--- a/pkg/math_utils/utils.go
+++ b/pkg/math_utils/utils.go
@@ -1,23 +1,24 @@
 package math_utils
 
 import (
-	"math/big"
-
 	"github.com/pkg/errors"
+	"math/big"
 )
 
 // Finds a nonnegative integer x < p such that (m * x) % p == n.
 func DivMod(n *big.Int, m *big.Int, p *big.Int) (*big.Int, error) {
-	if m.BitLen() == 0 {
-		return nil, errors.Errorf("m in div_mod(n, m, p) can't be zero")
-	}
-	inv_m := new(big.Int)
-	res := new(big.Int)
+	//if m.BitLen() == 0 {
+	//	return nil, errors.Errorf("m in div_mod(n, m, p) can't be zero")
+	//}
+	a := new(big.Int)
+	gcd := new(big.Int)
+	gcd.GCD(a, nil, m, p)
 
-	inv_m.ModInverse(m, p)
-	res.Mul(inv_m, n)
-	res.Mod(res, p)
-	return res, nil
+	if gcd.Cmp(big.NewInt(1)) != 0 {
+		return nil, errors.Errorf("gcd(%s, %s) != 1", m, p)
+	}
+
+	return n.Mul(n, a).Mod(n, p), nil
 }
 
 func ISqrt(x *big.Int) (*big.Int, error) {

--- a/pkg/math_utils/utils.go
+++ b/pkg/math_utils/utils.go
@@ -7,9 +7,6 @@ import (
 
 // Finds a nonnegative integer x < p such that (m * x) % p == n.
 func DivMod(n *big.Int, m *big.Int, p *big.Int) (*big.Int, error) {
-	//if m.BitLen() == 0 {
-	//	return nil, errors.Errorf("m in div_mod(n, m, p) can't be zero")
-	//}
 	a := new(big.Int)
 	gcd := new(big.Int)
 	gcd.GCD(a, nil, m, p)

--- a/pkg/math_utils/utils_test.go
+++ b/pkg/math_utils/utils_test.go
@@ -27,7 +27,7 @@ func TestDivModOk(t *testing.T) {
 	}
 }
 
-func TestDivModFail(t *testing.T) {
+func TestDivModMZeroFail(t *testing.T) {
 	a := new(big.Int)
 	b := new(big.Int)
 	prime := new(big.Int)
@@ -37,7 +37,22 @@ func TestDivModFail(t *testing.T) {
 
 	_, err := DivMod(a, b, prime)
 	if err == nil {
-		t.Errorf("DivMod expected to fail with division by zero")
+		t.Errorf("DivMod expected to failed with gcd != 1")
+	}
+}
+
+func TestDivModMEqPFail(t *testing.T) {
+	a := new(big.Int)
+	b := new(big.Int)
+	prime := new(big.Int)
+
+	a.SetString("11260647941622813594563746375280766662237311019551239924981511729608487775604310196863705127454617186486639011517352066501847110680463498585797912894788", 10)
+	b.SetString("800000000000011000000000000000000000000000000000000000000000001", 16)
+	prime.SetString("800000000000011000000000000000000000000000000000000000000000001", 16)
+
+	_, err := DivMod(a, b, prime)
+	if err == nil {
+		t.Errorf("DivMod expected to failed with gcd != 1")
 	}
 }
 


### PR DESCRIPTION
Use `GCD` instead of `MulInverse` for `DivMod` to better replicate cairo-lang's VM behavior.
Resolves: #211 