### PR TITLE
fix: Extract aliased constants from identifiers

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -40,14 +40,15 @@ type DebugInfo struct {
 }
 
 type Identifier struct {
-	FullName   string         `json:"full_name"`
-	Members    map[string]any `json:"members"`
-	Size       int            `json:"size"`
-	Decorators []string       `json:"decorators"`
-	PC         int            `json:"pc"`
-	Type       string         `json:"type"`
-	CairoType  string         `json:"cairo_type"`
-	Value      big.Int        `json:"value"`
+	FullName    string         `json:"full_name"`
+	Members     map[string]any `json:"members"`
+	Size        int            `json:"size"`
+	Decorators  []string       `json:"decorators"`
+	PC          int            `json:"pc"`
+	Type        string         `json:"type"`
+	CairoType   string         `json:"cairo_type"`
+	Value       big.Int        `json:"value"`
+	Destination string         `json:"destination"`
 }
 
 type ApTrackingData struct {

--- a/pkg/vm/program.go
+++ b/pkg/vm/program.go
@@ -76,7 +76,6 @@ func (p *Program) ExtractConstants() map[string]lambdaworks.Felt {
 			}
 		}
 	}
-
 	return constants
 }
 

--- a/pkg/vm/program.go
+++ b/pkg/vm/program.go
@@ -7,14 +7,15 @@ import (
 )
 
 type Identifier struct {
-	FullName   string
-	Members    map[string]any
-	Size       int
-	Decorators []string
-	PC         int
-	Type       string
-	CairoType  string
-	Value      lambdaworks.Felt
+	FullName    string
+	Members     map[string]any
+	Size        int
+	Decorators  []string
+	PC          int
+	Type        string
+	CairoType   string
+	Value       lambdaworks.Felt
+	Destination string
 }
 
 type Program struct {
@@ -53,6 +54,7 @@ func DeserializeProgramJson(compiledProgram parser.CompiledJson) Program {
 		programIdentifier.Type = identifier.Type
 		programIdentifier.CairoType = identifier.CairoType
 		programIdentifier.Value = lambdaworks.FeltFromDecString(identifier.Value.String())
+		programIdentifier.Destination = identifier.Destination
 		program.Identifiers[key] = programIdentifier
 	}
 	program.Hints = compiledProgram.Hints
@@ -64,9 +66,29 @@ func DeserializeProgramJson(compiledProgram parser.CompiledJson) Program {
 func (p *Program) ExtractConstants() map[string]lambdaworks.Felt {
 	constants := make(map[string]lambdaworks.Felt)
 	for name, identifier := range p.Identifiers {
-		if identifier.Type == "const" {
+		switch identifier.Type {
+		case "const":
 			constants[name] = identifier.Value
+		case "alias":
+			val, ok := searchConstFromAlias(identifier.Destination, &p.Identifiers)
+			if ok {
+				constants[name] = val
+			}
 		}
 	}
+
 	return constants
+}
+
+func searchConstFromAlias(destination string, identifiers *map[string]Identifier) (lambdaworks.Felt, bool) {
+	identifier, ok := (*identifiers)[destination]
+	if ok {
+		switch identifier.Type {
+		case "const":
+			return identifier.Value, true
+		case "alias":
+			return searchConstFromAlias(identifier.Destination, identifiers)
+		}
+	}
+	return lambdaworks.Felt{}, false
 }

--- a/pkg/vm/program_test.go
+++ b/pkg/vm/program_test.go
@@ -49,5 +49,34 @@ func TestExtractConstants(t *testing.T) {
 	if !reflect.DeepEqual(program.ExtractConstants(), expectedConstants) {
 		t.Errorf("Wrong Constants, expected %v, got %v", expectedConstants, program.ExtractConstants())
 	}
+}
 
+func TestExtractConstantsWithAliasedConstants(t *testing.T) {
+	program := vm.Program{
+		Identifiers: map[string]vm.Identifier{
+			"path.A": {
+				Value: lambdaworks.FeltFromUint64(7),
+				Type:  "const",
+			},
+			"path.b": {
+				Value: lambdaworks.FeltFromUint64(17),
+				Type:  "label",
+			},
+			"other_path.A": {
+				Destination: "path.A",
+				Type:        "alias",
+			},
+			"other_path.b": {
+				Destination: "path.b",
+				Type:        "alias",
+			},
+		},
+	}
+	expectedConstants := map[string]lambdaworks.Felt{
+		"path.A":       lambdaworks.FeltFromUint64(7),
+		"other_path.A": lambdaworks.FeltFromUint64(7),
+	}
+	if !reflect.DeepEqual(program.ExtractConstants(), expectedConstants) {
+		t.Errorf("Wrong Constants, expected %v, got %v", expectedConstants, program.ExtractConstants())
+	}
 }


### PR DESCRIPTION
When constants are imported from other modules, they appear as an alias in the compiled json. As we didn't take them into account when creating the constants map, hints that imported aliased constants would fail. For example:
```
"starkware.cairo.common.cairo_keccak.keccak.BLOCK_SIZE": {
            "destination": "starkware.cairo.common.cairo_keccak.packed_keccak.BLOCK_SIZE",
            "type": "alias"
        },
        "starkware.cairo.common.cairo_keccak.packed_keccak.BLOCK_SIZE": {
            "type": "const",
            "value": 3
        },
```
Here the hint executed with access to scope `starkware.cairo.common.cairo_keccak.keccak` needs the alias in order to access the `BLOCK_SIZE` constant imported from  starkware.cairo.common.cairo_keccak.packed_keccak