### PR TITLE
Abstract big integer representation for hints

### DIFF
--- a/pkg/hints/hint_processor.go
+++ b/pkg/hints/hint_processor.go
@@ -89,9 +89,9 @@ func (p *CairoVmHintProcessor) ExecuteHint(vm *vm.VirtualMachine, hintData *any,
 	case ASSERT_NOT_EQUAL:
 		return assert_not_equal(data.Ids, vm)
 	case EC_NEGATE:
-		return ecNegateImportSecpP(*vm, *execScopes, data.Ids)
+		return ecNegateImportSecpP(vm, *execScopes, data.Ids)
 	case EC_NEGATE_EMBEDDED_SECP:
-		return ecNegateEmbeddedSecpP(*vm, *execScopes, data.Ids)
+		return ecNegateEmbeddedSecpP(vm, *execScopes, data.Ids)
 	case POW:
 		return pow(data.Ids, vm)
 	case SQRT:

--- a/pkg/hints/hint_utils/bigint_utils.go
+++ b/pkg/hints/hint_utils/bigint_utils.go
@@ -9,6 +9,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// In cairo, various structs are used to represent big integers, all of them have numbered fields of Felt type (d0, d1,...) and share the same behaviours
+// This file contains an implementation of each behaviour at the limbs level, and the wrappers for each specific type
+
 // Generic methods for all types
 func limbsFromVarName(nLimbs int, name string, ids IdsManager, vm *VirtualMachine) ([]Felt, error) {
 	baseAddr, err := ids.GetAddr(name, vm)

--- a/pkg/hints/hint_utils/bigint_utils.go
+++ b/pkg/hints/hint_utils/bigint_utils.go
@@ -1,0 +1,56 @@
+package hint_utils
+
+import (
+	"math/big"
+
+	. "github.com/lambdaclass/cairo-vm.go/pkg/lambdaworks"
+	. "github.com/lambdaclass/cairo-vm.go/pkg/vm"
+	. "github.com/lambdaclass/cairo-vm.go/pkg/vm/memory"
+	"github.com/pkg/errors"
+)
+
+type Uint struct {
+	limbs []Felt
+}
+
+// Generic methods for all types
+func limbsFromVarName(nLimbs int, name string, ids IdsManager, vm *VirtualMachine) ([]Felt, error) {
+	baseAddr, err := ids.GetAddr(name, vm)
+	if err != nil {
+		return nil, err
+	}
+	return limbsFromBaseAddress(nLimbs, name, baseAddr, vm)
+}
+
+func limbsFromBaseAddress(nLimbs int, name string, addr Relocatable, vm *VirtualMachine) ([]Felt, error) {
+	limbs := make([]Felt, 0)
+	for i := 0; i < nLimbs; i++ {
+		felt, err := vm.Segments.Memory.GetFelt(addr.AddUint(uint(i)))
+		if err == nil {
+			limbs = append(limbs, felt)
+		} else {
+			return nil, errors.Errorf("Identifier %s has no member d%d", name, i)
+		}
+	}
+	return limbs, nil
+}
+
+func limbsPack86(limbs []Felt) big.Int {
+	sum := big.NewInt(0)
+	for i := 0; i < 3; i++ {
+		felt := limbs[i]
+		shifed := new(big.Int).Lsh(felt.ToSigned(), uint(i*86))
+		sum.Add(sum, shifed)
+	}
+	return *sum
+}
+
+func limbsPack(limbs []Felt) big.Int {
+	sum := big.NewInt(0)
+	for i := 0; i < len(limbs); i++ {
+		felt := limbs[i]
+		shifed := new(big.Int).Lsh(felt.ToSigned(), uint(i*128))
+		sum.Add(sum, shifed)
+	}
+	return *sum
+}

--- a/pkg/hints/hint_utils/bigint_utils.go
+++ b/pkg/hints/hint_utils/bigint_utils.go
@@ -51,6 +51,29 @@ func limbsPack(limbs []Felt) big.Int {
 	return *sum
 }
 
+func limbsInsertFromVarName(limbs []Felt, name string, ids IdsManager, vm *VirtualMachine) error {
+	baseAddr, err := ids.GetAddr(name, vm)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < len(limbs); i++ {
+		err = vm.Segments.Memory.Insert(baseAddr.AddUint(uint(i)), NewMaybeRelocatableFelt(limbs[i]))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func splitIntoLimbs(num *big.Int, numLimbs int) []Felt {
+	limbs := make([]Felt, 0, numLimbs)
+	bitmask := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
+	for i := 0; i < numLimbs; i++ {
+		limbs[i] = FeltFromBigInt(new(big.Int).Lsh(new(big.Int).And(num, bitmask), 128))
+	}
+	return limbs
+}
+
 // Concrete type definitions
 
 // BigInt3

--- a/pkg/hints/hint_utils/bigint_utils.go
+++ b/pkg/hints/hint_utils/bigint_utils.go
@@ -9,10 +9,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-type Uint struct {
-	limbs []Felt
-}
-
 // Generic methods for all types
 func limbsFromVarName(nLimbs int, name string, ids IdsManager, vm *VirtualMachine) ([]Felt, error) {
 	baseAddr, err := ids.GetAddr(name, vm)
@@ -53,4 +49,21 @@ func limbsPack(limbs []Felt) big.Int {
 		sum.Add(sum, shifed)
 	}
 	return *sum
+}
+
+// Concrete type definitions
+
+// BigInt3
+
+type BigInt3 struct {
+	Limbs []Felt
+}
+
+func (b *BigInt3) Pack86() big.Int {
+	return limbsPack86(b.Limbs)
+}
+
+func BigInt3FromBaseAddr(addr Relocatable, name string, vm *VirtualMachine) (BigInt3, error) {
+	limbs, err := limbsFromBaseAddress(3, name, addr, vm)
+	return BigInt3{Limbs: limbs}, err
 }


### PR DESCRIPTION
Across multiple hints, structs are used to represent big integers, all consisting of a set of Felts of varying size.
The logic is the same for all structs, so it doesn't make sense to implement it for each struct separately.
As we don't have const generics i go, we can't really make a generic structure to represent all of these types, but we can abstract the logic of each method into functions operating over a slice of Felts. And implement wrappers for each type using these methods
What this Pr does:
- Add functions that operate over the limbs `[]Felt` (fromBaseAddr, fromVarName, Pack, Pack86, Split, Insert)
- Implement a BigInt3 wrapper using these methods and replace the current implementation