### PR TITLE
Fix `math_utils.DivCeil`

### DIFF
--- a/pkg/utils/math_utils.go
+++ b/pkg/utils/math_utils.go
@@ -45,7 +45,7 @@ func MaxInt(x int, y int) int {
 
 func DivCeil(x uint, y uint) uint {
 	q := x / y
-	if q*y < x {
+	if x%y != 0 {
 		q++
 	}
 	return q

--- a/pkg/utils/math_utils.go
+++ b/pkg/utils/math_utils.go
@@ -44,5 +44,9 @@ func MaxInt(x int, y int) int {
 }
 
 func DivCeil(x uint, y uint) uint {
-	return 1 + (x-1)/y
+	q := x / y
+	if q*y < x {
+		q++
+	}
+	return q
 }


### PR DESCRIPTION
The current implementation yields incorrect values when x is zero. As this function is used when calculating the instances used by a builtin, when running a cairo program with a builtin who's  segment used size is zero, the vm would throw an invalid stop ptr error, as the used cells (calculated from used_size.div_ceil(cells_per_instance) * cells_per_instance) would not be zero