### PR TITLE
Fix ldl warning

### DIFF
--- a/pkg/lambdaworks/lambdaworks.go
+++ b/pkg/lambdaworks/lambdaworks.go
@@ -1,7 +1,7 @@
 package lambdaworks
 
 /*
-#cgo LDFLAGS: pkg/lambdaworks/lib/liblambdaworks.a -ldl
+#cgo LDFLAGS: pkg/lambdaworks/lib/liblambdaworks.a
 #include "lib/lambdaworks.h"
 #include <stdlib.h>
 */


### PR DESCRIPTION
There was a `duplicate -ldl flag` warning being printed because both the `lambdaworks` and `starknet_crypto` libraries were passing it