### PR TITLE
Add generic function to fetch scope variables with a generic type

### DIFF
--- a/pkg/types/exec_scope_test.go
+++ b/pkg/types/exec_scope_test.go
@@ -258,3 +258,21 @@ func TestErrExitMainScope(t *testing.T) {
 		t.Errorf("TestErrExitMainScope should fail with error: %s and fails with: %s", types.ErrCannotExitMainScop, err)
 	}
 }
+
+func TestFetchScopeVar(t *testing.T) {
+	scope := make(map[string]interface{})
+	scope["k"] = lambdaworks.FeltOne()
+
+	scopes := types.NewExecutionScopes()
+	scopes.EnterScope(scope)
+
+	result, err := types.FetchScopeVar[lambdaworks.Felt]("k", scopes)
+	if err != nil {
+		t.Errorf("TestGetLocalVariables failed with error: %s", err)
+
+	}
+	expected := lambdaworks.FeltOne()
+	if expected != result {
+		t.Errorf("TestGetLocalVariables failed, expected: %s, got: %s", expected.ToSignedFeltString(), result.ToSignedFeltString())
+	}
+}

--- a/pkg/types/exec_scopes.go
+++ b/pkg/types/exec_scopes.go
@@ -82,3 +82,20 @@ func (es *ExecutionScopes) Get(varName string) (interface{}, error) {
 	}
 	return val, nil
 }
+
+// Generic version of ExecutionScopes.Get which also handles casting
+func FetchScopeVar[T interface{}](varName string, scopes *ExecutionScopes) (T, error) {
+	locals, err := scopes.GetLocalVariables()
+	if err != nil {
+		return *new(T), err
+	}
+	valAny, prs := locals[varName]
+	if !prs {
+		return *new(T), ErrVariableNotInScope(varName)
+	}
+	val, ok := valAny.(T)
+	if !ok {
+		return *new(T), ErrVariableNotInScope(varName)
+	}
+	return val, nil
+}

--- a/pkg/types/exec_scopes.go
+++ b/pkg/types/exec_scopes.go
@@ -18,6 +18,10 @@ func ErrVariableNotInScope(varName string) error {
 	return ExecutionScopesError(errors.Errorf("Variable %s not in scope", varName))
 }
 
+func ErrVariableHasWrongType(varName string) error {
+	return ExecutionScopesError(errors.Errorf("Scope variable %s has wrong type", varName))
+}
+
 func NewExecutionScopes() *ExecutionScopes {
 	data := make([]map[string]interface{}, 1)
 	data[0] = make(map[string]interface{})
@@ -95,7 +99,7 @@ func FetchScopeVar[T interface{}](varName string, scopes *ExecutionScopes) (T, e
 	}
 	val, ok := valAny.(T)
 	if !ok {
-		return *new(T), ErrVariableNotInScope(varName)
+		return *new(T), ErrVariableHasWrongType(varName)
 	}
 	return val, nil
 }


### PR DESCRIPTION
The pattern scopes.Get -> handle error -> cast -> handle error is very frequent and quite annoying.
This PR adds a generic function `FetchScopeVar` which has the same functionality as scopes.Get, but also casts the scope variable to the generic type, handling the error.
This turns code that looks like this:
```
nAny, err := scopes.Get("N")
	if err != nil {
		return err
	}
n, ok := nAny.(*big.Int)
	if !ok {
		return errors.New("N not in scope")
	}
```
To something like this:

```
n, err := FetchScopeVar[*big.Int]("N", scopes)
	if err != nil {
		return err
	}
```
