### PR TITLE
Refactor error messages to lowercase and fix typos

### DIFF
--- a/pkg/vm/memory/memory.go
+++ b/pkg/vm/memory/memory.go
@@ -42,7 +42,7 @@ type Memory struct {
 	Data              map[Relocatable]MaybeRelocatable
 	numSegments       uint
 	validationRules   map[uint]ValidationRule
-	validatedAdresses AddressSet
+	validatedAddresses AddressSet
 	// This is a map of addresses that were accessed during execution
 	// The map is of the form `segmentIndex` -> `offset`. This is to
 	// make the counting of memory holes easier
@@ -67,7 +67,7 @@ func InsufficientAllocatedCellsErrorMinStepNotReached(minStep uint, builtinName 
 func NewMemory() *Memory {
 	return &Memory{
 		Data:              make(map[Relocatable]MaybeRelocatable),
-		validatedAdresses: NewAddressSet(),
+		validatedAddresses: NewAddressSet(),
 		validationRules:   make(map[uint]ValidationRule),
 		AccessedAddresses: make(map[Relocatable]bool),
 	}
@@ -171,7 +171,7 @@ func (m *Memory) AddValidationRule(SegmentIndex uint, rule ValidationRule) {
 // Applies the validation rule for the addr's segment if any
 // Skips validation if the address is temporary or if it has been previously validated
 func (m *Memory) validateAddress(addr Relocatable) error {
-	if addr.SegmentIndex < 0 || m.validatedAdresses.Contains(addr) {
+	if addr.SegmentIndex < 0 || m.validatedAddresses.Contains(addr) {
 		return nil
 	}
 	rule, ok := m.validationRules[uint(addr.SegmentIndex)]
@@ -183,7 +183,7 @@ func (m *Memory) validateAddress(addr Relocatable) error {
 		return err
 	}
 	for _, validated_address := range validated_addresses {
-		m.validatedAdresses.Add(validated_address)
+		m.validatedAddresses.Add(validated_address)
 	}
 	return nil
 }
@@ -192,7 +192,7 @@ func (m *Memory) MarkAsAccessed(address Relocatable) {
 	m.AccessedAddresses[address] = true
 }
 
-// Applies validation_rules to every memory address, if applicatble
+// Applies validation_rules to every memory address, if applicable
 // Skips validation if the address is temporary or if it has been previously validated
 func (m *Memory) ValidateExistingMemory() error {
 	for addr := range m.Data {

--- a/pkg/vm/memory/memory_test.go
+++ b/pkg/vm/memory/memory_test.go
@@ -166,7 +166,7 @@ func TestMemoryInsertOverWriteValue(t *testing.T) {
 	val2 := memory.NewMaybeRelocatableFelt(lambdaworks.FeltFromUint64(8))
 	err2 := mem.Insert(key, val2)
 	if err2 == nil {
-		t.Errorf("Overwritting memory value should fail")
+		t.Errorf("Overwriting memory value should fail")
 	}
 }
 

--- a/pkg/vm/memory/relocatable.go
+++ b/pkg/vm/memory/relocatable.go
@@ -75,7 +75,7 @@ func (r *Relocatable) IsEqual(r1 *Relocatable) bool {
 
 func (relocatable *Relocatable) SubUint(other uint) (Relocatable, error) {
 	if relocatable.Offset < other {
-		return NewRelocatable(0, 0), &SubReloctableError{Msg: "RelocatableSubUsizeNegOffset"}
+		return NewRelocatable(0, 0), &SubRelocatableError{Msg: "RelocatableSubUsizeNegOffset"}
 	} else {
 		new_offset := relocatable.Offset - other
 		return NewRelocatable(relocatable.SegmentIndex, new_offset), nil

--- a/pkg/vm/memory/relocatable.go
+++ b/pkg/vm/memory/relocatable.go
@@ -55,7 +55,7 @@ func (r *Relocatable) SubFelt(other lambdaworks.Felt) (Relocatable, error) {
 func (r *Relocatable) AddMaybeRelocatable(other MaybeRelocatable) (Relocatable, error) {
 	felt, ok := other.GetFelt()
 	if !ok {
-		return Relocatable{}, errors.New("Can't add two relocatable values")
+		return Relocatable{}, errors.New("can't add two relocatable values")
 	}
 	return r.AddFelt(felt)
 }
@@ -64,7 +64,7 @@ func (r *Relocatable) AddMaybeRelocatable(other MaybeRelocatable) (Relocatable, 
 // Fails if they have different segment indexes
 func (r *Relocatable) Sub(other Relocatable) (lambdaworks.Felt, error) {
 	if r.SegmentIndex != other.SegmentIndex {
-		return lambdaworks.Felt{}, errors.New("Cant subtract two relocatables with different segment indexes")
+		return lambdaworks.Felt{}, errors.New("can't subtract two relocatables with different segment indexes")
 	}
 	return lambdaworks.FeltFromUint64(uint64(r.Offset)).Sub(lambdaworks.FeltFromUint64(uint64(other.Offset))), nil
 }
@@ -143,7 +143,7 @@ func (m *MaybeRelocatable) RelocateValue(relocationTable *[]uint) (lambdaworks.F
 		return lambdaworks.FeltFromUint64(uint64(inner_relocatable.RelocateAddress(relocationTable))), nil
 	}
 
-	return lambdaworks.FeltZero(), errors.New(fmt.Sprintf("Unexpected type %T", m.inner))
+	return lambdaworks.FeltZero(), fmt.Errorf("unexpected type %T", m.inner)
 }
 
 func (m *MaybeRelocatable) IsEqual(m1 *MaybeRelocatable) bool {
@@ -229,7 +229,7 @@ func (m MaybeRelocatable) Sub(other MaybeRelocatable) (MaybeRelocatable, error) 
 		return *NewMaybeRelocatableFelt(res), err
 
 	} else {
-		return *NewMaybeRelocatableFelt(lambdaworks.FeltZero()), errors.New("Cant sub Relocatable from Felt")
+		return *NewMaybeRelocatableFelt(lambdaworks.FeltZero()), errors.New("can't sub Relocatable from Felt")
 	}
 }
 

--- a/pkg/vm/memory/relocatable_err.go
+++ b/pkg/vm/memory/relocatable_err.go
@@ -1,9 +1,9 @@
 package memory
 
-type SubReloctableError struct {
+type SubRelocatableError struct {
 	Msg string
 }
 
-func (e *SubReloctableError) Error() string {
+func (e *SubRelocatableError) Error() string {
 	return e.Msg
 }

--- a/pkg/vm/memory/relocatable_test.go
+++ b/pkg/vm/memory/relocatable_test.go
@@ -90,7 +90,7 @@ func TestRelocatableIsEqual(t *testing.T) {
 
 	is_equal := a.IsEqual(&b)
 	if !is_equal {
-		t.Errorf("TestRelocatableIsEqual failed epected true, got %v", is_equal)
+		t.Errorf("TestRelocatableIsEqual failed expected true, got %v", is_equal)
 	}
 
 }
@@ -101,7 +101,7 @@ func TestRelocatableIsNotEqual(t *testing.T) {
 
 	is_equal := a.IsEqual(&b)
 	if is_equal {
-		t.Errorf("TestRelocatableIsNotEqual failed epected false, got %v", is_equal)
+		t.Errorf("TestRelocatableIsNotEqual failed expected false, got %v", is_equal)
 	}
 }
 

--- a/pkg/vm/memory/segments.go
+++ b/pkg/vm/memory/segments.go
@@ -222,5 +222,5 @@ func (m *MemorySegmentManager) GenArg(arg any) (MaybeRelocatable, error) {
 		_, err := m.LoadData(base, &args)
 		return *NewMaybeRelocatableRelocatable(base), err
 	}
-	return *NewMaybeRelocatableFelt(lambdaworks.FeltZero()), errors.New("GenArg: found argument of invalid type.")
+	return *NewMaybeRelocatableFelt(lambdaworks.FeltZero()), errors.New("GenArg: found argument of invalid type")
 }

--- a/pkg/vm/memory/segments_test.go
+++ b/pkg/vm/memory/segments_test.go
@@ -315,8 +315,8 @@ func TestGenArgMaybeRelocatable(t *testing.T) {
 	segments := memory.NewMemorySegmentManager()
 	arg := any(*memory.NewMaybeRelocatableFelt(lambdaworks.FeltZero()))
 	expectedArg := *memory.NewMaybeRelocatableFelt(lambdaworks.FeltZero())
-	genedArg, err := segments.GenArg(arg)
-	if err != nil || !reflect.DeepEqual(expectedArg, genedArg) {
+	generatedArgs, err := segments.GenArg(arg)
+	if err != nil || !reflect.DeepEqual(expectedArg, generatedArgs) {
 		t.Error("GenArg failed or returned wrong value")
 	}
 }
@@ -327,8 +327,8 @@ func TestGenArgSliceMaybeRelocatable(t *testing.T) {
 
 	expectedBase := memory.NewRelocatable(0, 0)
 	expectedArg := *memory.NewMaybeRelocatableRelocatable(expectedBase)
-	genedArg, err := segments.GenArg(arg)
-	if err != nil || !reflect.DeepEqual(expectedArg, genedArg) {
+	generatedArgs, err := segments.GenArg(arg)
+	if err != nil || !reflect.DeepEqual(expectedArg, generatedArgs) {
 		t.Error("GenArg failed or returned wrong value")
 	}
 	val, err := segments.Memory.GetFelt(expectedBase)
@@ -344,9 +344,9 @@ func TestGenArgSliceSliceMaybeRelocatable(t *testing.T) {
 	expectedBaseA := memory.NewRelocatable(1, 0)
 	expectedBaseB := memory.NewRelocatable(0, 0)
 	expectedArg := *memory.NewMaybeRelocatableRelocatable(expectedBaseA)
-	genedArg, err := segments.GenArg(arg)
+	generatedArgs, err := segments.GenArg(arg)
 
-	if err != nil || !reflect.DeepEqual(expectedArg, genedArg) {
+	if err != nil || !reflect.DeepEqual(expectedArg, generatedArgs) {
 		t.Error("GenArg failed or returned wrong value")
 	}
 	valA, err := segments.Memory.GetRelocatable(expectedBaseA)


### PR DESCRIPTION
Updated error messages to lowercase and fixed typos in code.

- Changed error messages to start with lowercase for better style (as per go-staticcheck ST1005).
- Fixed typos.

This makes the code easier to read and follows Go's best practices.

Affected file(s):
- All files in `pkg/vm/memory/`

Test result:
<img width="518" alt="image" src="https://github.com/lambdaclass/cairo-vm_in_go/assets/94083757/6157456b-724f-42bd-956e-dd87bfc189f8">